### PR TITLE
fix displacy KeyError: settings bug #6

### DIFF
--- a/data_utils/data_utils.py
+++ b/data_utils/data_utils.py
@@ -57,7 +57,7 @@ class Sentence(object):
             ents.append({'start': ent.start_pos,
                          'end': ent.end_pos,
                          'label': ent.category})
-        ex = {'text': self.text, 'ents': ents, 'title': None}
+        ex = {'text': self.text, 'ents': ents, 'title': None, 'settings': {}}
         return displacy.render(ex,
                                style='ent',
                                options={'colors': COLOR_MAP},


### PR DESCRIPTION
[Displacy producing KeyError: 'settings' #3531](https://github.com/explosion/spaCy/issues/3531)
Add `settings = {}` to `Sentence._repr_html_`

#6 